### PR TITLE
Inject config `models` and `globals` into Jinja2 globals.

### DIFF
--- a/more/jinja2/main.py
+++ b/more/jinja2/main.py
@@ -16,6 +16,12 @@ def get_setting_section():
 @Jinja2App.template_loader(extension='.jinja2')
 def get_jinja2_loader(template_directories, settings):
     config = settings.jinja2.__dict__.copy()
+    _globals = config.pop('globals', {})
+    _models = config.pop('models', {})
+
+    _globals.update({
+        model.__name__: model for model in _models
+    })
 
     # we always want to use autoescape as this is about
     # HTML templating
@@ -24,9 +30,11 @@ def get_jinja2_loader(template_directories, settings):
         'extensions': ['jinja2.ext.autoescape']
     })
 
-    return jinja2.Environment(
+    env = jinja2.Environment(
         loader=jinja2.FileSystemLoader(template_directories),
         **config)
+    env.globals.update(_globals)
+    return env
 
 
 @Jinja2App.template_render(extension='.jinja2')

--- a/more/jinja2/tests/fixtures/inject_globals.py
+++ b/more/jinja2/tests/fixtures/inject_globals.py
@@ -1,0 +1,33 @@
+from more.jinja2 import Jinja2App
+
+
+class App(Jinja2App):
+    pass
+
+
+@App.path(path='persons/{name}')
+class Person(object):
+    def __init__(self, name):
+        self.name = name
+
+
+@App.template_directory()
+def get_template_dir():
+    return 'templates'
+
+
+@App.setting_section(section='jinja2')
+def get_setting_section():
+    def fancy_function():
+        return 'This is fancy'
+
+    return {
+        'globals': {
+            'fancy_function': fancy_function
+        }
+    }
+
+
+@App.html(model=Person, template='person_globals.jinja2')
+def person_default(self, request):
+    return {'name': self.name}

--- a/more/jinja2/tests/fixtures/inject_models.py
+++ b/more/jinja2/tests/fixtures/inject_models.py
@@ -1,0 +1,28 @@
+from more.jinja2 import Jinja2App
+
+
+class App(Jinja2App):
+    pass
+
+
+@App.path(path='persons/{name}')
+class Person(object):
+    def __init__(self, name):
+        self.name = name
+
+
+@App.template_directory()
+def get_template_dir():
+    return 'templates'
+
+
+@App.setting_section(section='jinja2')
+def get_setting_section():
+    return {
+        'models': [Person]
+    }
+
+
+@App.html(model=Person, template='person_link.jinja2')
+def person_default(self, request):
+    return {'name': self.name}

--- a/more/jinja2/tests/fixtures/templates/person_globals.jinja2
+++ b/more/jinja2/tests/fixtures/templates/person_globals.jinja2
@@ -1,0 +1,6 @@
+<html>
+<body>
+<p>Hello {{name}}!</p>
+<p>{{ fancy_function() }}</p>
+</body>
+</html>

--- a/more/jinja2/tests/fixtures/templates/person_link.jinja2
+++ b/more/jinja2/tests/fixtures/templates/person_link.jinja2
@@ -1,0 +1,6 @@
+<html>
+<body>
+<p>Hello {{name}}!</p>
+<p><a href="{{ request.link(Person('mars')) }}">Mars</a></p>
+</body>
+</html>

--- a/more/jinja2/tests/test_jinja2.py
+++ b/more/jinja2/tests/test_jinja2.py
@@ -1,7 +1,7 @@
 from webtest import TestApp as Client
 from .fixtures import (
     template, template_inheritance, override_template,
-    override_template_inheritance)
+    override_template_inheritance, inject_models, inject_globals)
 
 
 def test_template():
@@ -80,5 +80,31 @@ def test_override_template_inheritance():
 <div id="content2">
 <p>Hello world!</p>
 </div>
+</body>
+</html>'''
+
+
+def test_inject_globals():
+    c = Client(inject_globals.App())
+
+    response = c.get('/persons/world')
+    assert response.body == b'''\
+<html>
+<body>
+<p>Hello world!</p>
+<p>This is fancy</p>
+</body>
+</html>'''
+
+
+def test_inject_models():
+    c = Client(inject_models.App())
+
+    response = c.get('/persons/world')
+    assert response.body == b'''\
+<html>
+<body>
+<p>Hello world!</p>
+<p><a href="http://localhost/persons/mars">Mars</a></p>
 </body>
 </html>'''


### PR DESCRIPTION
Allows the user to inject elements in the Jinja2 Environment via the `globals` attribute. 

The main drive for this change is to be able to generate links in the Jinja templates without explictly having to pass models or instances into the context on each view, which can be useful when creating links in a base template.

The `models` setting is a convenience to save the user from creating `globals` dict manually.