### PR TITLE
drop support for old Python versions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = py27,py34,py35,py36,pypy,pypy3,pep8
 
 [testenv]
+setenv = PY_IGNORE_IMPORTMISMATCH = 1
 deps = -e{toxinidir}[test]
 commands = py.test {posargs}
 


### PR DESCRIPTION
see pytest issue
https://github.com/pytest-dev/pytest/issues/2042#issuecomment-429289164

I am not 100% sure about the root cause, but setting the environment
variable as suggested in the pytest issue, at least is a step forward,
ie pytest is able to collect the tests successfully.

modified:   tox.ini