### PR TITLE
Fix Jinja2 integration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,14 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://gitlab.com/pycqa/flake8
-    rev: "3.8.4"
+    rev: "3.9.2"
     hooks:
       - id: flake8
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.7.4
+    rev: v2.32.1
     hooks:
     - id: pyupgrade
       args: [--py36-plus]

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -26,6 +26,9 @@ CHANGES
 
 - Use GitHub Actions for CI.
 
+- Fix Jinja2 integration - the ``autoescape`` extension was removed as now it
+  is built-in.
+
 0.2 (2015-04-09)
 ================
 

--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,6 @@ in your app. For instance::
       return {
         'auto_reload': False,
         'autoescape': True,
-        'extensions': ['jinja2.ext.autoescape']
       }
 
 For details on Jinja2 configuration options, consult the `Jinja2 API

--- a/more/jinja2/main.py
+++ b/more/jinja2/main.py
@@ -19,7 +19,7 @@ def get_jinja2_loader(template_directories, settings):
 
     # we always want to use autoescape as this is about
     # HTML templating
-    config.update({"autoescape": True, "extensions": ["jinja2.ext.autoescape"]})
+    config.update({"autoescape": True})
 
     return jinja2.Environment(
         loader=jinja2.FileSystemLoader(template_directories), **config

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,6 @@ setup(
         "Programming Language :: Python :: 3.9",
     ],
     python_requires=">=3.6",
-    install_requires=["setuptools", "morepath >= 0.15", "Jinja2 >= 2.7.3"],
+    install_requires=["setuptools", "morepath >= 0.15", "Jinja2 >= 2.9"],
     extras_require=dict(test=["pytest >= 2.6.0", "pytest-cov", "WebTest"]),
 )


### PR DESCRIPTION
The `autoescape` extension has been removed as it is now a built-in.